### PR TITLE
If BPB exists, insert dock before it in the DOM

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -93,7 +93,7 @@ const dock = function(options) {
 
   this.addClass('vjs-dock');
 
-  const bpbIndex = player.children().indexOf(player.getChild('bigPlayButton'));
+  const bpbIndex = this.children().indexOf(this.getChild('bigPlayButton'));
   const index = bpbIndex > 0 ? bpbIndex - 1 : null;
 
   if (!title) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -93,13 +93,16 @@ const dock = function(options) {
 
   this.addClass('vjs-dock');
 
+  const bpbIndex = player.children().indexOf(player.getChild('bigPlayButton'));
+  const index = bpbIndex > 0 ? bpbIndex - 1 : null;
+
   if (!title) {
-    title = this.title = this.addChild('title', settings.title);
+    title = this.title = this.addChild('title', settings.title, index);
   } else {
     title.update(settings.title.title, settings.title.description);
   }
   if (!shelf) {
-    shelf = this.shelf = this.addChild('shelf', settings);
+    shelf = this.shelf = this.addChild('shelf', settings, index);
   }
 
   this.one(title, 'dispose', function() {


### PR DESCRIPTION
Putting the dock before the big play button in the DOM makes it so that
the dock will not appear in front of modal dialogs that are inserted as
player children normally.