### PR TITLE
feat: add player labelledBy and describedBy aria based on title and description elements

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -122,9 +122,9 @@ const dock = function(options) {
       this.shelf = null;
     });
 
-    // Update aria attributes to describe video content if title
-    // and description IDs are present. If unavailable, accessibility
-    // landmark can fall back to generic `Video Player` label.
+    // Update aria attributes to describe video content if title/description
+    // IDs and inner text are present. If unavailable, accessibility
+    // landmark can fall back to generic `Video Player` aria-label.
     const titleEl = title.title;
     const descriptionEl = title.description;
     const titleId = titleEl.id;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -122,6 +122,9 @@ const dock = function(options) {
       this.shelf = null;
     });
 
+    // Update aria attributes to describe video content if title
+    // and description IDs are available. If unavailable, accessibility
+    // landmark can fall back to generic `Video Player` label.
     const titleId = title.title.id;
     const descriptionId = title.description.id;
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -123,7 +123,7 @@ const dock = function(options) {
     });
 
     // Update aria attributes to describe video content if title
-    // and description IDs are available. If unavailable, accessibility
+    // and description IDs are present. If unavailable, accessibility
     // landmark can fall back to generic `Video Player` label.
     const titleEl = title.title;
     const descriptionEl = title.description;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -125,14 +125,16 @@ const dock = function(options) {
     // Update aria attributes to describe video content if title
     // and description IDs are available. If unavailable, accessibility
     // landmark can fall back to generic `Video Player` label.
-    const titleId = title.title.id;
-    const descriptionId = title.description.id;
+    const titleEl = title.title;
+    const descriptionEl = title.description;
+    const titleId = titleEl.id;
+    const descriptionId = descriptionEl.id;
 
-    if (titleId) {
+    if (titleId && titleEl.innerText) {
       this.setAttribute('aria-labelledby', titleId);
     }
 
-    if (descriptionId) {
+    if (descriptionId && descriptionEl.innerText) {
       this.setAttribute('aria-describedby', descriptionId);
     }
   }, true);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -121,6 +121,17 @@ const dock = function(options) {
     this.one(shelf, 'dispose', function() {
       this.shelf = null;
     });
+
+    const titleId = title.title.id;
+    const descriptionId = title.description.id;
+
+    if (titleId) {
+      this.setAttribute('aria-labelledby', titleId);
+    }
+
+    if (descriptionId) {
+      this.setAttribute('aria-describedby', descriptionId);
+    }
   }, true);
 };
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -56,3 +56,25 @@ QUnit.test('registers itself with video.js', function(assert) {
     'the plugin adds a class to the player'
   );
 });
+
+QUnit.test('adds aria attributes', function(assert) {
+  assert.expect(2);
+
+  this.player.dock({
+    title: 'Test Title',
+    description: 'Test description.'
+  });
+
+  // Tick the clock forward enough to trigger the player to be "ready".
+  this.clock.tick(1);
+
+  assert.ok(
+    this.player.getAttribute('aria-labelledby').includes('vjs-dock-title'),
+    'the plugin adds an aria-labelledby to the player based on title ID'
+  );
+
+  assert.ok(
+    this.player.getAttribute('aria-describedby').includes('vjs-dock-description'),
+    'the plugin adds an aria-describedby to the player based on description ID'
+  );
+});

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -57,7 +57,7 @@ QUnit.test('registers itself with video.js', function(assert) {
   );
 });
 
-QUnit.test('adds aria attributes', function(assert) {
+QUnit.test('adds aria attributes to the player when both title and description values are present in options', function(assert) {
   assert.expect(2);
 
   this.player.dock({
@@ -68,13 +68,62 @@ QUnit.test('adds aria attributes', function(assert) {
   // Tick the clock forward enough to trigger the player to be "ready".
   this.clock.tick(1);
 
+  const titleId = this.player.title.title.id;
+  const descriptionId = this.player.title.description.id;
+
   assert.ok(
-    this.player.getAttribute('aria-labelledby').includes('vjs-dock-title'),
+    this.player.getAttribute('aria-labelledby').includes(titleId),
     'the plugin adds an aria-labelledby to the player based on title ID'
   );
 
   assert.ok(
-    this.player.getAttribute('aria-describedby').includes('vjs-dock-description'),
+    this.player.getAttribute('aria-describedby').includes(descriptionId),
     'the plugin adds an aria-describedby to the player based on description ID'
+  );
+});
+
+QUnit.test('adds aria-labelledby attribute to the player when only title is passed through options', function(assert) {
+  assert.expect(2);
+
+  this.player.dock({
+    title: 'Test Title'
+  });
+
+  // Tick the clock forward enough to trigger the player to be "ready".
+  this.clock.tick(1);
+
+  const titleId = this.player.title.title.id;
+
+  assert.ok(
+    this.player.getAttribute('aria-labelledby').includes(titleId),
+    'the plugin adds an aria-labelledby to the player based on title ID'
+  );
+
+  assert.ok(
+    this.player.getAttribute('aria-describedby') === null,
+    'the plugin does not add an empty aria-describedby to the player if description text is ""'
+  );
+});
+
+QUnit.test('adds aria-describedby attribute to the player when only description is passed through options', function(assert) {
+  assert.expect(2);
+
+  this.player.dock({
+    description: 'Test description.'
+  });
+
+  // Tick the clock forward enough to trigger the player to be "ready".
+  this.clock.tick(1);
+
+  const descriptionId = this.player.title.description.id;
+
+  assert.ok(
+    this.player.getAttribute('aria-describedby').includes(descriptionId),
+    'the plugin adds an aria-describedby to the player based on description ID'
+  );
+
+  assert.ok(
+    this.player.getAttribute('aria-labelledby') === null,
+    'the plugin does not add an empty aria-labelledby to the player if title text is ""'
   );
 });


### PR DESCRIPTION
Add `aria-labelledby` and `aria-describedby` attributes to player wrapper, based on dock title and description element IDs, to create descriptive accessibility landmarks.

If `title` and/or `description` values are not passed down to the plugin via options or are left empty, the attributes will not be added to the player and the landmark text will fall back to the existing `aria-label`, which is `Video Player`.