### PR TITLE
fix: keep player's label in labelledby list

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -131,7 +131,7 @@ const dock = function(options) {
     const descriptionId = descriptionEl.id;
 
     if (titleId && titleEl.textContent) {
-      this.setAttribute('aria-labelledby', titleId);
+      this.setAttribute('aria-labelledby', this.id() + ' ' + titleId);
     }
 
     if (descriptionId && descriptionEl.textContent) {


### PR DESCRIPTION
Just speaking the title of a video may be confusing, we should still convey to Screen Reader users that this is a Video/Audio Player.